### PR TITLE
Set `listchars`

### DIFF
--- a/plugin/neovim_defaults.vim
+++ b/plugin/neovim_defaults.vim
@@ -14,7 +14,7 @@ if has('syntax') && !exists('g:syntax_on')
   syntax enable
 endif
 
-" Settings based on :help nvim-option-defaults
+" Settings based on :help nvim-defaults
 set autoindent
 set autoread
 set backspace=indent,eol,start

--- a/plugin/neovim_defaults.vim
+++ b/plugin/neovim_defaults.vim
@@ -27,6 +27,7 @@ set hlsearch
 set incsearch
 set langnoremap
 set laststatus=2
+set listchars=tab:>\ ,trail:-,nbsp:+
 set mouse=a
 set nrformats=hex
 set sessionoptions-=options


### PR DESCRIPTION
The default value of `listchars` was changed to `tab:> ,trail:-,nbsp:+` in https://github.com/neovim/neovim/commit/be29de.
